### PR TITLE
Fixes three minor bugs

### DIFF
--- a/src/Manifest.zig
+++ b/src/Manifest.zig
@@ -39,7 +39,9 @@ pub fn from_text(allocator: Allocator, text: []const u8) !Manifest {
         dependencies.deinit();
     }
 
-    if (root.get("dependencies")) |dependencies_node| {
+    if (root.get("dependencies")) |dependencies_node| blk: {
+        if (dependencies_node == .empty)
+            break :blk;
         if (dependencies_node != .object)
             return error.DependenciesIsNotObject;
 


### PR DESCRIPTION
1. Prevents build.zig.zon corruption when writing the output file crashes (due to missing `.hash`)
2. Handles empty dependencies properly
3. Prevents memory corruption when `read_in_dependencies` fails